### PR TITLE
Fix Mail subdomain direction

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -33,7 +33,13 @@
   
   @mail host mail.jenspot.com
   handle @mail {
-    reverse_proxy 192.168.0.18
+    rewrite * /mail{uri}
+    reverse_proxy https://192.168.0.18:443 {
+      header_up Host {upstream_hostport}
+      transport http { 
+        tls_insecure_skip_verify
+      }
+    }
   }
 
   @resources host resources.jenspot.com


### PR DESCRIPTION
Mail.jenspot.com was returning redirect errors due to roundcube web server using strictly HTTPS. The reverse proxy did not pass traffic to the web server properly. Using rewrite to hide /mail path and terminate TLS with tls_insecure_skip_verify though it might be removed later down the line.